### PR TITLE
Fix: Failled to install plugins/themes with slug contains 'and'

### DIFF
--- a/src/classes/Instruction.php
+++ b/src/classes/Instruction.php
@@ -103,7 +103,7 @@ class Instruction {
 		if ( ! empty( $where_clause ) ) {
 			$where_clause = trim( preg_replace( '#^[\s]*where(.*)$#i', '$1', $where_clause ) );
 
-			$clauses = preg_split( '#and#i', $where_clause );
+			$clauses = preg_split( '#\sand\s#i', $where_clause );
 
 			foreach ( $clauses as $clause ) {
 				$clause = trim( $clause );

--- a/src/classes/InstructionTypes/InstallPlugin.php
+++ b/src/classes/InstructionTypes/InstallPlugin.php
@@ -148,7 +148,7 @@ class InstallPlugin extends InstructionType {
 				$version = 'trunk';
 			}
 
-			$result = PackageManager::instance()->install_from_org( $options['plugin name'], $version );
+			$result = PackageManager::instance()->install_plugin_from_org( $options['plugin name'], $version );
 
 			if ( is_null( $result ) || is_wp_error( $result ) ) {
 				Log::instance()->write( 'Could not install plugin.', 0, 'error' );


### PR DESCRIPTION
### Description of the Change

Include space in `preg_split` call to correctly match `and` keyword, not the `and` string in theme/plugin name.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Benefits

Allow installing plugins/themes with `and` string in the slug.

### Verification Process

Try to install a plugin with slug contains `and`. E.g. `command-palette`.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues

Closes #1.